### PR TITLE
Fix incorrect temperature output in Energia+MSP430

### DIFF
--- a/am2320-int.cpp
+++ b/am2320-int.cpp
@@ -49,7 +49,8 @@ byte AM2320::Read()
   Rcrc += buf[6];
   if (Rcrc == CRC16(buf, 6)) {
     t = ((buf[4] & 0x7F) << 8) + buf[5]; // x10, don't forget to divide by 10!
-    t = ((buf[4] & 0x80) >> 7) == 1 ? t * (-1) : t;
+    //t = ((buf[4] & 0x80) >> 7) == 1 ? t * (-1) : t;
+    if (((buf[4] & 0x80) >> 7) == 1) t = t * (-1);
 
     unsigned int humidity = (buf[2] << 8) + buf[3];
     h = byte (humidity / 10);


### PR DESCRIPTION
Original code returned only positive values